### PR TITLE
fix: allow a wider range of filenames

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1271,6 +1271,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "iban_validate"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1d358f7ae89819e8656f1b495c9d760a9ca315998b12d589dc516c9f81ed08"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "icu_collections"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1555,6 +1564,7 @@ dependencies = [
  "fontdb 0.17.0",
  "futures",
  "garde",
+ "iban_validate",
  "lopdf",
  "regex",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,6 +507,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.73",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+
+[[package]]
 name = "cobs"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,6 +557,12 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "comemo"
@@ -1504,6 +1599,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1559,6 +1660,7 @@ dependencies = [
  "axum-test",
  "axum-valid",
  "axum_typed_multipart",
+ "clap",
  "comemo",
  "dotenv",
  "fontdb 0.17.0",
@@ -3648,6 +3750,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,6 +638,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-url"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -857,6 +870,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "forwarded-header-value"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9"
+dependencies = [
+ "nonempty",
+ "thiserror",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -926,6 +949,12 @@ name = "futures-task"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -1021,6 +1050,26 @@ name = "gimli"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+
+[[package]]
+name = "governor"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a7f542ee6b35af73b06abc0dad1c1bae89964e4e253bc4b587b91c9637867b"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures",
+ "futures-timer",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand",
+ "smallvec",
+ "spinning_top",
+]
 
 [[package]]
 name = "half"
@@ -1517,6 +1566,7 @@ dependencies = [
  "tokio",
  "tower",
  "tower-http",
+ "tower_governor",
  "tracing",
  "tracing-subscriber",
  "typst",
@@ -1726,6 +1776,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16cf681a23b4d0a43fc35024c176437f9dcd818db34e0f42ab456a0ee5ad497b"
 
 [[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1734,6 +1790,18 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "nonempty"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "nu-ansi-term"
@@ -2101,6 +2169,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edecfcd5d755a5e5d98e24cf43113e7cdaec5a070edd0f6b250c03a573da30fa"
 
 [[package]]
+name = "quanta"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5167a477619228a0b284fac2674e3c388cba90631d7b7de620e6f1fcd08da5"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2202,6 +2285,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb9ee317cfe3fbd54b36a511efc1edd42e216903c9cd575e686dd68a2ba90d8d"
+dependencies = [
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -2682,6 +2774,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3090,6 +3191,22 @@ name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
+name = "tower_governor"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "313fa625fea5790ed56360a30ea980e41229cf482b4835801a67ef1922bf63b9"
+dependencies = [
+ "axum",
+ "forwarded-header-value",
+ "governor",
+ "http 1.1.0",
+ "pin-project",
+ "thiserror",
+ "tower",
+ "tracing",
+]
 
 [[package]]
 name = "tracing"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1507,6 +1507,7 @@ dependencies = [
  "futures",
  "garde",
  "lopdf",
+ "regex",
  "reqwest",
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ axum-valid = { version = "0.14.0", features = [
     "typed_multipart",
 ], default-features = false }
 axum_typed_multipart = "0.11.0"
+clap = { version = "4.5.16", features = ["env", "derive"] }
 comemo = { version = "0.4.0" }
 dotenv = "0.15.0"
 fontdb = { version = "0.17.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ reqwest = { version = "0.12.5", default-features = false, features = ["multipart
 lopdf = "0.33.0"
 regex = "1.10.6"
 tower_governor = { version = "0.4.2", features = ["axum"] }
+iban_validate = "4.0.1"
 
 [dev-dependencies]
 tower = { version = "0.4.13", features = ["util"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ fontdb = { version = "0.17.0", optional = true }
 typst-assets = { version = "0.11.1", features = ["fonts"] }
 reqwest = { version = "0.12.5", default-features = false, features = ["multipart", "rustls-tls"] }
 lopdf = "0.33.0"
+regex = "1.10.6"
 
 [dev-dependencies]
 tower = { version = "0.4.13", features = ["util"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ typst-assets = { version = "0.11.1", features = ["fonts"] }
 reqwest = { version = "0.12.5", default-features = false, features = ["multipart", "rustls-tls"] }
 lopdf = "0.33.0"
 regex = "1.10.6"
+tower_governor = { version = "0.4.2", features = ["axum"] }
 
 [dev-dependencies]
 tower = { version = "0.4.13", features = ["util"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,29 +20,29 @@ axum-valid = { version = "0.14.0", features = [
     "typed_multipart",
 ], default-features = false }
 axum_typed_multipart = "0.11.0"
+comemo = { version = "0.4.0" }
 dotenv = "0.15.0"
-serde = "1.0.195"
-serde_derive = "1.0.195"
-thiserror = "1.0.56"
-tokio = { version = "1.35.1", features = ["full"] }
-tower-http = { version = "0.5.1", features = ["trace", "limit", "cors"] }
-tracing = "0.1.40"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-serde_json = "1.0.111"
+fontdb = { version = "0.17.0", optional = true }
 futures = "0.3.30"
 garde = "0.17.0"
-typst = { version = "0.11.1" }
-typst-pdf = { version = "0.11.1" }
-comemo = { version = "0.4.0" }
-time = { version = "0.3.36" }
-fontdb = { version = "0.17.0", optional = true }
-typst-assets = { version = "0.11.1", features = ["fonts"] }
-reqwest = { version = "0.12.5", default-features = false, features = ["multipart", "rustls-tls"] }
+iban_validate = "4.0.1"
 lopdf = "0.33.0"
 regex = "1.10.6"
+reqwest = { version = "0.12.5", default-features = false, features = ["multipart", "rustls-tls"] }
+serde = "1.0.195"
+serde_derive = "1.0.195"
+serde_json = "1.0.111"
+thiserror = "1.0.56"
+time = { version = "0.3.36" }
+tokio = { version = "1.35.1", features = ["full"] }
+tower-http = { version = "0.5.1", features = ["trace", "limit", "cors"] }
 tower_governor = { version = "0.4.2", features = ["axum"] }
-iban_validate = "4.0.1"
+tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+typst = { version = "0.11.1" }
+typst-assets = { version = "0.11.1", features = ["fonts"] }
+typst-pdf = { version = "0.11.1" }
 
 [dev-dependencies]
-tower = { version = "0.4.13", features = ["util"] }
 axum-test = "14.2.2"
+tower = { version = "0.4.13", features = ["util"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN touch src/main.rs
 RUN cargo build --release
 
 FROM alpine as runtime
+ENV BIND_ADDR 0.0.0.0
 WORKDIR /app
 COPY --from=builder /app/target/release/laskugeneraattori app
 EXPOSE 5237

--- a/src/api/invoices.rs
+++ b/src/api/invoices.rs
@@ -142,11 +142,6 @@ pub async fn create(
             .collect::<Vec<_>>(),
     )?;
 
-    tokio::task::spawn(async move {
-        if let Err(e) = client.send_mail(multipart.data).await {
-            error!("Sending invoice failed: {}", e);
-        }
-    });
-
+    client.send_mail(multipart.data).await?;
     Ok((StatusCode::CREATED, axum::Json(orig)))
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,8 +1,12 @@
 use axum::{
     extract::DefaultBodyLimit,
+    http::Method,
     routing::{get, post},
     Router,
 };
+use std::sync::Arc;
+use std::time::Duration;
+use tower_governor::{governor::GovernorConfigBuilder, GovernorLayer};
 use tower_http::{cors::CorsLayer, limit::RequestBodyLimitLayer, trace::TraceLayer};
 
 pub mod invoices;
@@ -13,6 +17,22 @@ pub fn app() -> Router<crate::state::State> {
         "http://localhost:3000".parse().unwrap(),
     ]);
 
+    let governor_config = Arc::new(
+        GovernorConfigBuilder::default()
+            .const_period(Duration::from_secs(720))
+            .burst_size(5)
+            .use_headers()
+            .methods(vec![Method::POST])
+            .finish()
+            .unwrap(),
+    );
+    let governor_limiter = governor_config.limiter().clone();
+
+    std::thread::spawn(move || loop {
+        std::thread::sleep(Duration::from_secs(60));
+        governor_limiter.retain_recent();
+    });
+
     Router::new()
         .route("/health", get(health))
         .route("/invoices", post(invoices::create))
@@ -21,6 +41,9 @@ pub fn app() -> Router<crate::state::State> {
         .layer(DefaultBodyLimit::disable())
         // Limit the body to 24 MiB since the email is limited to 25 MiB
         .layer(RequestBodyLimitLayer::new(24 * 1024 * 1024))
+        .layer(GovernorLayer {
+            config: governor_config,
+        })
 }
 
 async fn health() {}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,6 +1,6 @@
 use axum::{
     extract::DefaultBodyLimit,
-    http::Method,
+    http::{HeaderValue, Method},
     routing::{get, post},
     Router,
 };
@@ -12,10 +12,13 @@ use tower_http::{cors::CorsLayer, limit::RequestBodyLimitLayer, trace::TraceLaye
 pub mod invoices;
 
 pub fn app() -> Router<crate::state::State> {
-    let cors_layer = CorsLayer::new().allow_origin([
-        "https://tietokilta.fi".parse().unwrap(),
-        "http://localhost:3000".parse().unwrap(),
-    ]);
+    let cors_layer = CorsLayer::new().allow_origin(
+        crate::CONFIG
+            .allowed_origins
+            .iter()
+            .map(|c| c.parse::<HeaderValue>().unwrap())
+            .collect::<Vec<_>>(),
+    );
 
     let governor_config = Arc::new(
         GovernorConfigBuilder::default()

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -46,4 +46,6 @@ pub fn app() -> Router<crate::state::State> {
         })
 }
 
-async fn health() {}
+async fn health() -> &'static str {
+    "OK"
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,7 +38,7 @@ impl IntoResponse for Error {
         error!(%self);
 
         let status = match self {
-            Error::InternalServerError(_) | Error::ReqwestError(_) => {
+            Error::InternalServerError(_) | Error::ReqwestError(_) | Error::TypstError => {
                 StatusCode::INTERNAL_SERVER_ERROR
             }
             Error::JsonError(_)
@@ -47,7 +47,6 @@ impl IntoResponse for Error {
             | Error::MultipartRejection(_)
             | Error::JsonRejection(_)
             | Error::UnsupportedFileFormat(_) => StatusCode::BAD_REQUEST,
-            Error::TypstError => StatusCode::INTERNAL_SERVER_ERROR,
         };
 
         (

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,6 +16,8 @@ pub enum Error {
     MultipartRejection(#[from] axum::extract::multipart::MultipartRejection),
     #[error("Missing filename multipart")]
     MissingFilename,
+    #[error("Unsupported file format: {0}")]
+    UnsupportedFileFormat(String),
     #[error("Error in handling json value")]
     JsonRejection(#[from] axum::extract::rejection::JsonRejection),
     #[error("Error while parsing json")]
@@ -43,7 +45,8 @@ impl IntoResponse for Error {
             | Error::MissingFilename
             | Error::MultipartError(_)
             | Error::MultipartRejection(_)
-            | Error::JsonRejection(_) => StatusCode::BAD_REQUEST,
+            | Error::JsonRejection(_)
+            | Error::UnsupportedFileFormat(_) => StatusCode::BAD_REQUEST,
             Error::TypstError => StatusCode::INTERNAL_SERVER_ERROR,
         };
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,7 +16,7 @@ pub enum Error {
     MultipartRejection(#[from] axum::extract::multipart::MultipartRejection),
     #[error("Missing filename multipart")]
     MissingFilename,
-    #[error("Unsupported file format: {0}")]
+    #[error("Unsupported file format: {0}. Supported file formats are (jpg|jpeg|png|gif|svg|pdf)")]
     UnsupportedFileFormat(String),
     #[error("Error in handling json value")]
     JsonRejection(#[from] axum::extract::rejection::JsonRejection),

--- a/src/mailgun/invoices.rs
+++ b/src/mailgun/invoices.rs
@@ -13,7 +13,6 @@ impl MailgunClient {
         pdfs.extend_from_slice(
             invoice
                 .attachments
-                .clone()
                 .into_iter()
                 .map(|a| a.bytes)
                 .collect::<Vec<_>>()
@@ -39,19 +38,6 @@ impl MailgunClient {
                 "attachment",
                 reqwest::multipart::Part::bytes(pdf).file_name("invoice.pdf"),
             );
-
-        let form = invoice
-            .attachments
-            .into_iter()
-            .try_fold(form, |form, attachment| {
-                Ok::<reqwest::multipart::Form, Error>(
-                    form.part(
-                        "attachment",
-                        reqwest::multipart::Part::bytes(attachment.bytes)
-                            .file_name(attachment.filename.clone()),
-                    ),
-                )
-            })?;
 
         let response = self
             .client

--- a/src/mailgun/mod.rs
+++ b/src/mailgun/mod.rs
@@ -7,14 +7,27 @@ use axum::{
 
 mod invoices;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct MailgunClient {
-    pub client: reqwest::Client,
-    pub url: String,
-    pub api_user: String,
-    pub api_key: String,
-    pub default_to: String,
-    pub from: String,
+    client: reqwest::Client,
+    url: String,
+    api_user: String,
+    api_key: String,
+    default_to: String,
+    from: String,
+}
+
+impl From<crate::MailgunConfig> for MailgunClient {
+    fn from(config: crate::MailgunConfig) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            url: config.url,
+            api_user: config.user,
+            api_key: config.password,
+            default_to: config.to,
+            from: config.from,
+        }
+    }
 }
 
 #[async_trait]

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,12 @@ async fn main() {
         .await
         .expect("Failed to bind TcpListener");
 
-    axum::serve(listener, api::app().with_state(state))
-        .await
-        .expect("Failed to start server");
+    axum::serve(
+        listener,
+        api::app()
+            .with_state(state)
+            .into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .await
+    .expect("Failed to start server");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,7 @@ struct LaskugenConfig {
     allowed_origins: Vec<String>,
 }
 
-static CONFIG: LazyLock<LaskugenConfig> = LazyLock::new(|| LaskugenConfig::parse());
+static CONFIG: LazyLock<LaskugenConfig> = LazyLock::new(LaskugenConfig::parse);
 
 #[tokio::main]
 async fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
+use clap::Parser;
 use std::net::SocketAddr;
+use std::sync::LazyLock;
 
 mod api;
 mod error;
@@ -16,6 +18,43 @@ mod tests;
 #[macro_use]
 extern crate tracing;
 
+#[derive(Parser, Clone, Debug)]
+struct MailgunConfig {
+    /// Url used by mailgun
+    #[clap(long = "mailgun-url", env = "MAILGUN_URL")]
+    url: String,
+    /// Username used by mailgun
+    #[clap(long = "mailgun-user", env = "MAILGUN_USER")]
+    user: String,
+    /// Password used by mailgun
+    #[clap(long = "mailgun-password", env = "MAILGUN_PASSWORD")]
+    password: String,
+    /// Initial To-value used by mailgun
+    #[clap(long = "mailgun-to", env = "MAILGUN_TO")]
+    to: String,
+    /// From-value used by mailgun
+    #[clap(long = "mailgun-from", env = "MAILGUN_FROM")]
+    from: String,
+}
+
+#[derive(Parser, Clone, Debug)]
+#[command(version, about, long_about = None)]
+struct LaskugenConfig {
+    #[clap(flatten)]
+    mailgun: MailgunConfig,
+    /// The listen port for the HTTP server
+    #[clap(long, env, required = false, default_value = "3000")]
+    port: u16,
+    /// The ip address to bound by the HTTP server
+    #[clap(long, env, required = false, default_value = "127.0.0.1")]
+    bind_addr: std::net::IpAddr,
+    /// A comma-separated list of allowed origins
+    #[clap(long, env, required = false, value_delimiter = ',')]
+    allowed_origins: Vec<String>,
+}
+
+static CONFIG: LazyLock<LaskugenConfig> = LazyLock::new(|| LaskugenConfig::parse());
+
 #[tokio::main]
 async fn main() {
     dotenv::dotenv().ok();
@@ -27,19 +66,7 @@ async fn main() {
         .init();
 
     let state = state::new().await;
-
-    let ip = if std::env::var("EXPOSE").unwrap_or("0".into()) == "1" {
-        [0, 0, 0, 0]
-    } else {
-        [127, 0, 0, 1]
-    };
-
-    let addr = SocketAddr::from((
-        ip,
-        std::env::var("PORT")
-            .map(|p| p.parse::<u16>().unwrap())
-            .unwrap_or(3000),
-    ));
+    let addr = SocketAddr::from((CONFIG.bind_addr, CONFIG.port));
     debug!("Listening on {addr}");
     let listener = tokio::net::TcpListener::bind(addr)
         .await

--- a/src/state.rs
+++ b/src/state.rs
@@ -10,17 +10,8 @@ pub struct State {
 pub async fn new() -> State {
     dotenv::dotenv().ok();
 
-    let mailgun_client = MailgunClient {
-        client: reqwest::Client::new(),
-        url: std::env::var("MAILGUN_URL").expect("No MAILGUN_URL in env"),
-        api_user: std::env::var("MAILGUN_USER").expect("No MAILGUN_USER in env"),
-        api_key: std::env::var("MAILGUN_PASSWORD").expect("No MAILGUN_PASSWORD in env"),
-        default_to: std::env::var("MAILGUN_TO").expect("No MAILGUN_TO in env"),
-        from: std::env::var("MAILGUN_FROM").expect("No MAILGUN_FROM in env"),
-    };
-
     State {
-        mailgun_client,
+        mailgun_client: MailgunClient::from(crate::CONFIG.mailgun.clone()),
         for_garde: (),
     }
 }

--- a/templates/invoice.typ
+++ b/templates/invoice.typ
@@ -117,7 +117,7 @@
 )
 
 #for file in data.attachments {
-  if regex(".*\.(jpg|png)$") in file.filename {
+  if regex("(?i)\.(jpg|jpeg|png|gif|svg)$") in file.filename {
     pagebreak()
     image("/attachments/" + file.filename)
   }


### PR DESCRIPTION
This PR improves on filename matching in order to e.g. render .jpeg files as parts of the pdf.
Additionally it disallows unsupported filenames entirely, returing an error if encountered.

This includes the current progress of #23 but is to be merged beforehand in order to get the hotter fixes in ASAP