### PR TITLE
fix: prevent attachment filename from overflowing the table cell

### DIFF
--- a/templates/invoice.typ
+++ b/templates/invoice.typ
@@ -89,12 +89,17 @@
 
 *IBAN-tilinumero*: #data.bank_account_number \
 
+
 === LIITTEET
-#table(columns: (33%, 66%),
+#table(columns: (1fr, 2fr),
   table.header([*Tiedosto*], [*Kuvaus*]),
   ..data.attachments
     .zip(data.attachment_descriptions)
-    .map(((a, d)) => (a.filename, d)).flatten()
+    .map(((a, d)) => (
+      // NOTE: add breakpoints to the string
+      // so that it can be wrapped to multiple lines
+      a.filename.codepoints().map(x => x + sym.zws).join(),
+    d)).flatten()
 )
 
 #for file in data.attachments {


### PR DESCRIPTION
The filenames generally don't contain breakpoints and therefore
if a filename is longer than (1/3) of the page width it will overflow
and be displayed on top of the description.

This PR fixes the issue by inserting zero-width spaces between every
character in the filename.

## Before
![image](https://github.com/user-attachments/assets/9fab2694-5835-4b85-9777-cf1950b510bf)

## After
![image](https://github.com/user-attachments/assets/c0b8b2f3-394a-4bb3-b469-d11f5e4f9081)
