### PR TITLE
chore: make email an optional feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -889,9 +889,9 @@ checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "fdeflate"
@@ -1679,6 +1679,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "tempfile",
  "thiserror",
  "time",
  "tokio",
@@ -1700,9 +1701,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "libm"
@@ -2652,9 +2653,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "aa260229e6538e52293eeb577aabd09945a09d6d9cc0fc550ed7529056c2e32a"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -3084,9 +3085,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
 dependencies = [
  "cfg-if",
  "fastrand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,9 @@ authors = ["Luukas Pörtfors <lajp@iki.fi>"]
 lto = true
 
 [features]
+default = ["email"]
 system_fonts = ["dep:fontdb"]
+email = ["dep:reqwest"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -29,7 +31,7 @@ garde = "0.17.0"
 iban_validate = "4.0.1"
 lopdf = { git = "https://github.com/J-F-Liu/lopdf.git", rev = "7f24a1c3ebc42470a37b4315b843331e4f81cdcd" }
 regex = "1.10.6"
-reqwest = { version = "0.12.5", default-features = false, features = ["multipart", "rustls-tls"] }
+reqwest = { version = "0.12.5", default-features = false, features = ["multipart", "rustls-tls"], optional = true }
 serde = "1.0.195"
 serde_derive = "1.0.195"
 serde_json = "1.0.111"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ reqwest = { version = "0.12.5", default-features = false, features = ["multipart
 serde = "1.0.195"
 serde_derive = "1.0.195"
 serde_json = "1.0.111"
+tempfile = "3.13.0"
 thiserror = "1.0.56"
 time = { version = "0.3.36" }
 tokio = { version = "1.35.1", features = ["full"] }

--- a/src/api/invoices.rs
+++ b/src/api/invoices.rs
@@ -1,17 +1,22 @@
 use std::sync::LazyLock;
 
 use crate::error::Error;
+#[cfg(feature = "email")]
 use crate::mailgun::MailgunClient;
-use axum::{async_trait, body::Bytes, http::StatusCode, Json};
+
+use axum::{async_trait, body::Bytes, http::StatusCode};
 use axum_typed_multipart::{
     FieldData, FieldMetadata, TryFromChunks, TryFromMultipart, TypedMultipart, TypedMultipartError,
 };
+
 use axum_valid::Garde;
 use futures::stream::Stream;
 use garde::Validate;
 use iban::Iban;
 use regex::Regex;
 use serde_derive::{Deserialize, Serialize};
+
+use typst::model::Document;
 
 static ALLOWED_FILENAME: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?i)\.(jpg|jpeg|png|gif|svg|pdf)$").unwrap());
@@ -129,19 +134,61 @@ fn try_handle_file(field: FieldData<Bytes>) -> Result<InvoiceAttachment, Error> 
     })
 }
 
-pub async fn create(
+#[cfg(feature = "email")]
+pub async fn create_email(
     client: MailgunClient,
     Garde(TypedMultipart(mut multipart)): Garde<TypedMultipart<InvoiceForm>>,
-) -> Result<(StatusCode, Json<Invoice>), Error> {
+) -> Result<(StatusCode, axum::Json<Invoice>), Error> {
     let orig = multipart.data.clone();
-    multipart.data.attachments = Result::from_iter(
+    multipart.data.attachments =
+        Result::from_iter(multipart.attachments.into_iter().map(try_handle_file))?;
+
+    let document: Document = multipart.data.to_owned().try_into()?;
+    let pdf = typst_pdf::pdf(&document, typst::foundations::Smart::Auto, None);
+
+    let mut pdfs = vec![pdf];
+    pdfs.extend_from_slice(
         multipart
+            .data
             .attachments
             .into_iter()
-            .map(try_handle_file)
-            .collect::<Vec<_>>(),
-    )?;
+            .map(|a| a.bytes)
+            .collect::<Vec<_>>()
+            .as_slice(),
+    );
 
-    client.send_mail(multipart.data).await?;
+    let pdf = crate::merge::merge_pdf(pdfs)?;
+
+    client.send_mail(&orig, pdf).await?;
     Ok((StatusCode::CREATED, axum::Json(orig)))
+}
+
+#[cfg(not(feature = "email"))]
+pub async fn create(
+    Garde(TypedMultipart(mut multipart)): Garde<TypedMultipart<InvoiceForm>>,
+) -> Result<axum::response::Response, Error> {
+    multipart.data.attachments =
+        Result::from_iter(multipart.attachments.into_iter().map(try_handle_file))?;
+
+    let document: Document = multipart.data.to_owned().try_into()?;
+    let pdf = typst_pdf::pdf(&document, typst::foundations::Smart::Auto, None);
+
+    let mut pdfs = vec![pdf];
+    pdfs.extend_from_slice(
+        multipart
+            .data
+            .attachments
+            .into_iter()
+            .map(|a| a.bytes)
+            .collect::<Vec<_>>()
+            .as_slice(),
+    );
+
+    let pdf = crate::merge::merge_pdf(pdfs)?;
+
+    Ok(axum::response::Response::builder()
+        .status(StatusCode::CREATED)
+        .header("Content-Type", "application/pdf")
+        .body(Bytes::from(pdf).into())
+        .unwrap())
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -38,7 +38,13 @@ pub fn app() -> Router<crate::state::State> {
 
     Router::new()
         .route("/health", get(health))
-        .route("/invoices", post(invoices::create))
+        .route(
+            "/invoices",
+            #[cfg(feature = "email")]
+            post(invoices::create_email),
+            #[cfg(not(feature = "email"))]
+            post(invoices::create),
+        )
         .layer(TraceLayer::new_for_http())
         .layer(cors_layer)
         .layer(DefaultBodyLimit::disable())

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,6 +8,7 @@ use serde_derive::Serialize;
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[cfg(feature = "email")]
     #[error("Reqwest error {0}")]
     ReqwestError(#[from] reqwest::Error),
     #[error("Error while parsing multipart form")]
@@ -38,9 +39,9 @@ impl IntoResponse for Error {
         error!(%self);
 
         let status = match self {
-            Error::InternalServerError(_) | Error::ReqwestError(_) | Error::TypstError => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
+            Error::InternalServerError(_) | Error::TypstError => StatusCode::INTERNAL_SERVER_ERROR,
+            #[cfg(feature = "email")]
+            Error::ReqwestError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             Error::JsonError(_)
             | Error::MissingFilename
             | Error::MultipartError(_)

--- a/src/mailgun/invoices.rs
+++ b/src/mailgun/invoices.rs
@@ -1,26 +1,9 @@
 use super::MailgunClient;
 use crate::api::invoices::Invoice;
 use crate::error::Error;
-use crate::merge::merge_pdf;
-use typst::model::Document;
 
 impl MailgunClient {
-    pub async fn send_mail(self, invoice: Invoice) -> Result<(), Error> {
-        let document: Document = invoice.to_owned().try_into()?;
-        let pdf = typst_pdf::pdf(&document, typst::foundations::Smart::Auto, None);
-
-        let mut pdfs = vec![pdf];
-        pdfs.extend_from_slice(
-            invoice
-                .attachments
-                .into_iter()
-                .map(|a| a.bytes)
-                .collect::<Vec<_>>()
-                .as_slice(),
-        );
-
-        let pdf = merge_pdf(pdfs)?;
-
+    pub async fn send_mail(self, invoice: &Invoice, pdf: Vec<u8>) -> Result<(), Error> {
         let invoice_recipient = format!("{} <{}>", invoice.recipient_name, invoice.recipient_email);
         let form = reqwest::multipart::Form::new()
             .text("from", self.from)

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use std::sync::LazyLock;
 
 mod api;
 mod error;
+#[cfg(feature = "email")]
 mod mailgun;
 mod merge;
 mod state;
@@ -18,6 +19,7 @@ mod tests;
 #[macro_use]
 extern crate tracing;
 
+#[cfg(feature = "email")]
 #[derive(Parser, Clone, Debug)]
 struct MailgunConfig {
     /// Url used by mailgun
@@ -40,6 +42,7 @@ struct MailgunConfig {
 #[derive(Parser, Clone, Debug)]
 #[command(version, about, long_about = None)]
 struct LaskugenConfig {
+    #[cfg(feature = "email")]
     #[clap(flatten)]
     mailgun: MailgunConfig,
     /// The listen port for the HTTP server

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,8 +1,11 @@
+#[cfg(feature = "email")]
 use crate::mailgun::MailgunClient;
+
 use axum::extract::FromRef;
 
 #[derive(FromRef, Clone)]
 pub struct State {
+    #[cfg(feature = "email")]
     pub mailgun_client: MailgunClient,
     pub for_garde: (),
 }
@@ -11,6 +14,7 @@ pub async fn new() -> State {
     dotenv::dotenv().ok();
 
     State {
+        #[cfg(feature = "email")]
         mailgun_client: MailgunClient::from(crate::CONFIG.mailgun.clone()),
         for_garde: (),
     }


### PR DESCRIPTION
When running with `--no-default-features` (or in general without the "email"-feature)
the generated PDFs are returned in the response body instead of them being sent via email.

This may be useful for debugging.
