### PR TITLE
removed unit price and amount from items

### DIFF
--- a/src/api/invoices.rs
+++ b/src/api/invoices.rs
@@ -98,12 +98,6 @@ pub struct InvoiceRow {
     /// The product can be at most 128 characters
     #[garde(byte_length(max = 128))]
     pub product: String,
-    /// The quantity of the product, must be positive
-    #[garde(range(min = 1))]
-    pub quantity: i32,
-    /// The unit can be at most 128 characters
-    #[garde(byte_length(max = 128))]
-    pub unit: String,
     /// Unit price is encoded as number of cents to avoid floating-point precision bugs
     /// must be positive
     #[garde(range(min = 1))]

--- a/templates/invoice.typ
+++ b/templates/invoice.typ
@@ -82,13 +82,12 @@
 *Perustelut*: #data.description \
 
 === Erittely
-#let rows = data.rows.map(it => ([#it.product], [#it.quantity #it.unit],
-      [#price(it.unit_price) €], [#price(it.quantity*it.unit_price) €]))
-#table(columns: (55%, 15%, 15%, 15%),
-  align: (left, right, right, right),
-  table.header([*Tuote*], [*Määrä*],  [*Hinta per*], [*Yhteensä*]),
+#let rows = data.rows.map(it => ([#it.product],[#price(it.unit_price) €]))
+#table(columns: (75%, 25%),
+  align: (left, right),
+  table.header([*Kuitti/Tuote*], [*Summa*]),
   ..rows.flatten(),
-  ..([], [], [], [*#price(data.rows.map(r => r.unit_price*r.quantity).sum()) €*])
+  ..([],[*#price(data.rows.map(r => r.unit_price).sum()) €*])
 )
 
 *IBAN-tilinumero*: #data.bank_account_number \


### PR DESCRIPTION
Makes invoice generator simpler to use by making items be defined by just the receipt/product and price.