### PR TITLE
docs: document how to run without mailgun integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,4 @@ MAILGUN_USER="api"
 MAILGUN_PASSWORD=
 MAILGUN_TO="Rahastonhoitaja <rahastonhoitaja@tietokilta.fi>"
 MAILGUN_FROM="noreply@laskutus.tietokilta.fi"
+MAILGUN_DISABLE=

--- a/README.md
+++ b/README.md
@@ -20,17 +20,52 @@ MAILGUN_USER=
 MAILGUN_PASSWORD=
 MAILGUN_TO=
 MAILGUN_FROM=
+MAILGUN_DISABLE= # disable mailgun, e.g. for local testing
 ```
 
 ## Running laskugeneraattori
 
+To run without mailgun (e.g. for local testing), set env variable `MAILGUN_DISABLE=true`. The resulting pdf is saved to temp folder, path can be found from the server output.
+
 ### With cargo
+
 ```sh
 cargo run
 ```
 
 ### With Docker
+
 ```sh
 docker build . -t laskugeneraattori
 docker run laskugeneraattori
-``
+```
+
+## Sending invoices with curl
+
+Especially in local development/testing, it is useful to be able to send invoices via curl.
+
+For example:
+
+```sh
+curl -v -F data="$(cat invoice.json)" -F attachments="@file1.pdf" http://localhost:3000/invoices
+```
+
+With `invoice.json` being something like
+
+```json
+{
+  "recipient_name": "Test Name",
+  "recipient_email": "test@example.com",
+  "address": {
+    "street": "Street name",
+    "city": "Espoo",
+    "zip": "02150"
+  },
+  "phone_number": "+358401234567",
+  "subject": "Subject",
+  "description": "Description",
+  "bank_account_number": "FI1410093000123458",
+  "rows": [{ "product": "Product 1", "unit_price": 100 }],
+  "attachment_descriptions": ["Attachment"]
+}
+```


### PR DESCRIPTION
Updated README.md and .env.example about MAILGUN_DISABLE env var that allows running without mailgun, e.g. for local testing. This is especially important as the behaviour changed in #56.

Also added documentation about how to create invoices using curl.